### PR TITLE
Use PORT environment variable for production port.

### DIFF
--- a/grunt/connect.js
+++ b/grunt/connect.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var developmentPort = process.env.PORT || 9000;
-var productionPort = 8080;
+var productionPort = process.env.PORT || 8080;
 
 module.exports = {
   options: {


### PR DESCRIPTION
If PORT is set in the environment, use that for production, not just development.
This allows prod to run on a port other than 8080 (which may already be in use,
as it is a commonly used port.)

Probably the same should be done for host (override localhost), but I do not know what
the logic in dist.options.hostname is meant to do or why it is structured as is.